### PR TITLE
/ban /unban for Channel Hosts without tmpop or similar.

### DIFF
--- a/conf/bnetd.conf.in
+++ b/conf/bnetd.conf.in
@@ -518,9 +518,9 @@ initkill_timer = 120
 # WOLv2, WOL WILL FAIL IF YOU DO!
 
 #wolv1addrs = ":4000"
-#wolv2addrs = ":4005"
-#wgameresaddrs = ":4807"
-#apiregaddrs = ":5400"
+wolv2addrs = ":4005"
+wgameresaddrs = ":4807"
+apiregaddrs = ":5400"
 
 # Just leave these as default (unless you know the timezone, longitiude and latitude
 # of your server

--- a/conf/bnetd.conf.win32
+++ b/conf/bnetd.conf.win32
@@ -501,9 +501,9 @@ initkill_timer = 120
 # WOLv2, WOL WILL FAIL IF YOU DO!
 
 #wolv1addrs = ":4000"
-#wolv2addrs = ":4005"
-#wgameresaddrs = ":4807"
-#apiregaddrs = ":5400"
+wolv2addrs = ":4005"
+wgameresaddrs = ":4807"
+apiregaddrs = ":5400"
 
 # Just leave these as default (unless you know the timezone, longitiude and latitude
 # of your server

--- a/src/bnetd/command.cpp
+++ b/src/bnetd/command.cpp
@@ -2559,11 +2559,23 @@ namespace pvpgn
 			return 0;
 		}
 
+		//Helper-Methods, used to allow channel-hosts use /ban /unban (_handle_ban_command, _handle_unban_command)
+		//FIXME: Should be in another place.
+		std::string extractUsername(const std::string& fullString) {
+    		return fullString.substr(0, fullString.length() - 7);
+		}
+
+		bool isUserChannelHost(const std::string& channelName, const std::string& username) {
+    		std::string chUserName = extractUsername(channelName);
+    		return chUserName == username;
+		}
+
 		static int _handle_ban_command(t_connection * c, char const *text)
 		{
 			char const * username;
 			t_channel *    channel;
 			t_connection * buc;
+			char const * chHostName = conn_get_chatname(c); //Channel-Host
 
 			std::vector<std::string> args = split_command(text, 2);
 
@@ -2583,7 +2595,8 @@ namespace pvpgn
 			if (account_get_auth_admin(conn_get_account(c), NULL) != 1 && /* default to false */
 				account_get_auth_admin(conn_get_account(c), channel_get_name(channel)) != 1 && /* default to false */
 				account_get_auth_operator(conn_get_account(c), NULL) != 1 && /* default to false */
-				account_get_auth_operator(conn_get_account(c), channel_get_name(channel)) != 1) /* default to false */
+				account_get_auth_operator(conn_get_account(c), channel_get_name(channel)) && /* default to false */
+				!isUserChannelHost(channel_get_name(channel), chHostName)) //Check if user is Channel-Host
 			{
 				message_send_text(c, message_type_error, c, localize(c, "You have to be at least a Channel Operator to use this command."));
 				return -1;
@@ -2635,7 +2648,8 @@ namespace pvpgn
 		static int _handle_unban_command(t_connection * c, char const *text)
 		{
 			t_channel *  channel;
-
+			char const * chHostName = conn_get_chatname(c); //Channel-Host
+			
 			std::vector<std::string> args = split_command(text, 1);
 
 			if (args[1].empty())
@@ -2653,7 +2667,8 @@ namespace pvpgn
 			if (account_get_auth_admin(conn_get_account(c), NULL) != 1 && /* default to false */
 				account_get_auth_admin(conn_get_account(c), channel_get_name(channel)) != 1 && /* default to false */
 				account_get_auth_operator(conn_get_account(c), NULL) != 1 && /* default to false */
-				account_get_auth_operator(conn_get_account(c), channel_get_name(channel)) != 1) /* default to false */
+				account_get_auth_operator(conn_get_account(c), channel_get_name(channel)) != 1 && /* default to false */
+				!isUserChannelHost(channel_get_name(channel), chHostName)) //Check if user is Channel-Host
 			{
 				message_send_text(c, message_type_error, c, localize(c, "You are not a channel operator."));
 				return -1;


### PR DESCRIPTION
A kind of makeshift solution so that Channel Hosts can ban users without using tmpop or admin rights. Hosts should have these rights by default. Also, I uncommented the cc related port settings in bnetd.conf.